### PR TITLE
Deploy error occured, when TypeScript Vue Project.

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -38,7 +38,8 @@ module.exports = (api, options) => {
       gitignoreFile: '.gitignore',
       indexFile: 'public/index.html',
       readme: 'README.md',
-      vuetifyPluginFile: usesTypescript && 'src/plugins/vuetify.ts' in files ? 'src/plugins/vuetify.ts' : false
+      vuetifyPluginFile: usesTypescript && 'src/plugins/vuetify.ts' in files ? 'src/plugins/vuetify.ts' : false,
+      tsConfig: usesTypescript ? 'tsconfig.json' : false
     });
   });
 

--- a/generator/templates/src/server/Service.ts
+++ b/generator/templates/src/server/Service.ts
@@ -1,30 +1,9 @@
-/* eslint-disable  @typescript-eslint/ban-ts-ignore */
-/* eslint-disable  @typescript-eslint/no-explicit-any */
-
 'use strict';
 
-interface IPostData {
-  length: number;
-  type: string;
-  contents: string;
-  name: string;
-}
-
-interface IGetEvent {
-  queryString: string;
-  parameter: object;
-  parameters: object;
-  contextPath: string;
-  contentLength: number;
-  postData: IPostData;
-}
-
-function doGet(e: IGetEvent) {
-  //@ts-ignore
-  var html = HtmlService.createTemplateFromFile('index');
+function doGet(e: GoogleAppsScript.Events.DoGet) {
+  const html = HtmlService.createTemplateFromFile('index');
   return html.evaluate()
     .addMetaTag('viewport', 'width=device-width, initial-scale=1')
-    //@ts-ignore
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
     .setTitle(process.env.VUE_APP_TITLE)
     .setFaviconUrl(process.env.VUE_APP_FAVICON);

--- a/generator/templates/src/server/Service.ts
+++ b/generator/templates/src/server/Service.ts
@@ -21,7 +21,7 @@ interface IGetEvent {
 
 function doGet(e: IGetEvent) {
   //@ts-ignore
-  var html = HtmlService.createTemplateFromFile('_index');
+  var html = HtmlService.createTemplateFromFile('index');
   return html.evaluate()
     .addMetaTag('viewport', 'width=device-width, initial-scale=1')
     //@ts-ignore

--- a/google.mock/index.d.ts
+++ b/google.mock/index.d.ts
@@ -1,0 +1,3 @@
+// NOTE: merely avoid typescript error
+declare const GoogleMock: any
+export default GoogleMock

--- a/utils/VueGasPlugin.d.ts
+++ b/utils/VueGasPlugin.d.ts
@@ -1,0 +1,3 @@
+// NOTE: merely avoid typescript error
+declare const VueGasPlugin: any
+export default VueGasPlugin

--- a/utils/fileUpdater.js
+++ b/utils/fileUpdater.js
@@ -20,7 +20,6 @@ const updaters = (api, options) => {
     if (usesTypescript && usesEslint) {
       lines[0] = [
         '/* eslint-disable  @typescript-eslint/ban-ts-ignore */',
-        '/* eslint-disable  @typescript-eslint/no-explicit-any */',
         '',
         lines[0]
       ].join('\n');
@@ -176,6 +175,17 @@ const updaters = (api, options) => {
     return lines.join('\n');
   }
 
+  const tsConfig = (content) => {
+
+    const tsConfigObj = JSON.parse(content);
+    if (!tsConfigObj.exclude) {
+        tsConfigObj.exclude = []
+    }
+    tsConfigObj.exclude.push('src/server/**/*.ts');
+
+    return JSON.stringify(tsConfigObj, null, 2);
+  }
+
   return {
     entryFile,
     vueComponent,
@@ -186,7 +196,8 @@ const updaters = (api, options) => {
     gitignoreFile,
     indexFile,
     readme,
-    vuetifyPluginFile
+    vuetifyPluginFile,
+    tsConfig
   }
 };
 


### PR DESCRIPTION
I applyed this plugin  to TypeScript Vue project(created by vue-cli v4) and `yarn deploy`, I met following errors.

* Server-side files(`Server.ts`) transpiled by client-side build process.
* In entry file(`main.ts`), `@typescript-eslint/no-explicit-any` is not working.
* After deploy, I accessed but runtime error occured(not found `_index`).

I fixed these errors. And modify `Server.ts` to use the definition `@types/google-apps-script`. Kindly check these commits.