### PR TITLE
Google mock Success/Failure callback fired at once, and execute in same thread

### DIFF
--- a/google.mock/index.js
+++ b/google.mock/index.js
@@ -98,9 +98,6 @@ class Runner {
     if (this.successHandler) {
       this.successHandler('in case of success it would respond within the successHandler callback, with the following user object:', this.userObject);
     }
-    if (this.failureHandler) {
-      this.failureHandler('in case of failure it would respond within the failureHandler callback, with the following user object:', this.userObject);
-    }
   }
 }
 

--- a/google.mock/index.js
+++ b/google.mock/index.js
@@ -96,7 +96,9 @@ class Runner {
     const style = 'color: white; font-style: bold; background-color: #0277BD; padding: 2px 5px; border-radius: 3px;'
     console.info(`In production, you would have called the server-side %c${name} method`, style);
     if (this.successHandler) {
-      this.successHandler('in case of success it would respond within the successHandler callback, with the following user object:', this.userObject);
+      setTimeout(() => {
+          this.successHandler('in case of success it would respond within the successHandler callback, with the following user object:', this.userObject);
+      }, 0);
     }
   }
 }


### PR DESCRIPTION
When server-side method called in development mode, callbacks (registered by `withSuccessHandler` and `withFailureHandler`) fired at once, and callbacks executed same thread. Originaly, server-side methods are asynchronous. But in development mode, it behaves like synchronous.

I think, in development, only success callback should fired, because of easy to development for now.

