### PR TITLE
Set server-side mock data in development mode.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -44,6 +44,10 @@ All your calls to methods in `google.script.history`, `google.script.host` and `
 
 The `google` global object will be available in the Vue instance as `$google`. Thus, the right way to invoke `google.script.run` inside your components is by calling `this.$google.script.run`.
 
+In development, you can mock up the response of server-side functions. Seeing file (`./src/mock-data/responseMock.js`), you will find the example. You can specify mock data with JavaScript Object. The property name is server-side function name, and value is object which has two properties, `isSuccess` and `response`. If `isSuccess` is true, then `withSuccessHandler` will be invoked, if that is false, then `withFailureHandler` will be invoked. At that time, `response` will path as the first argument.
+
+> IMPORTANT: if the value is string, it must include actual quotes inside of the string itself.
+
 The Vue instance will also have the boolean property `$devMode`, which will be true when `process.env.NODE_ENV !== 'production'`, as well as three custom methods: `$callLibraryMethod`, `$log` and `$errorHandler`, which are intended to work together with the `callback`, `log` and `errorHandler` server-side functions. 
 
 The first of these methods is useful to call methods of libraries you use as dependencies in your server-side code or of any other global namespace. You should pass to it the following parameters: `library:string`, `method:string` and `args:array`. It returns a `Promise`.

--- a/generator/templates/src/components/HelloWorld.vue
+++ b/generator/templates/src/components/HelloWorld.vue
@@ -9,6 +9,7 @@ replace:
     <div style="display: flex; align-items: center; justify-content: center; margin: 10px;">
       <input type="button" style="margin: 10px; padding: 5px 10px; background-color: #BDBDBD; color: #212121;" value="click to test $log method" @click="handler">
     </div>
+    <div>{{ response }}</div>
   </div>
 </template>
 <%# END_REPLACE %>
@@ -18,7 +19,15 @@ replace:
 export default {
   name: 'HelloWorld',
   props: {
-    msg: String
+    msg: String,
+    response: String
+  },
+  mounted() {
+    this.$google.script.run
+      .withSuccessHandler((response) => {
+        this.response = response;
+      })
+      .sampleFunction();
   },
   methods: {
     handler() {

--- a/generator/templates/src/mock-data/responseMock.js
+++ b/generator/templates/src/mock-data/responseMock.js
@@ -1,5 +1,7 @@
-export const sampleMockData = [{
-  funcName: 'sampleFunction',
-  isSuccess: true,
-  response: 'This is development mode.'
-}];
+module.exports = {
+  sampleFunction: {
+    isSuccess: true,
+    // NOTE: if the value is string, it must include actual quotes inside of the string itself.
+    response: '"This is development mode."' // or JSON.stringify('This is development mode.')
+  }
+}

--- a/generator/templates/src/mock-data/responseMock.js
+++ b/generator/templates/src/mock-data/responseMock.js
@@ -1,0 +1,5 @@
+export const sampleMockData = [{
+  funcName: 'sampleFunction',
+  isSuccess: true,
+  response: 'This is development mode.'
+}];

--- a/generator/templates/src/server/Service.js
+++ b/generator/templates/src/server/Service.js
@@ -12,3 +12,7 @@ function doGet(e) {
 const callback = (library, method, ...args) => {
   return this[library][method].apply(this, args);
 }
+
+function sampleFunction() {
+  return 'This is product mode';
+}

--- a/generator/templates/src/server/Service.js
+++ b/generator/templates/src/server/Service.js
@@ -14,5 +14,5 @@ const callback = (library, method, ...args) => {
 }
 
 function sampleFunction() {
-  return 'This is product mode';
+  return 'This is production mode';
 }

--- a/generator/templates/src/server/Service.ts
+++ b/generator/templates/src/server/Service.ts
@@ -14,5 +14,5 @@ const callback = (library: string, method: string, ...args: any) => {
 }
 
 function sampleFunction(): string {
-  return 'This is product mode';
+  return 'This is production mode';
 }

--- a/generator/templates/src/server/Service.ts
+++ b/generator/templates/src/server/Service.ts
@@ -12,3 +12,7 @@ function doGet(e: GoogleAppsScript.Events.DoGet) {
 const callback = (library: string, method: string, ...args: any) => {
   return this[library][method].apply(this, args);
 }
+
+function sampleFunction(): string {
+  return 'This is product mode';
+}

--- a/google.mock/index.js
+++ b/google.mock/index.js
@@ -73,6 +73,21 @@ const enableServerMockedMethods = (obj) => {
   });
 }
 
+let responseMapping;
+
+const setMockData = (mockDataArr) => {
+  responseMapping = new Map();
+  if (!Array.isArray(mockDataArr)) {
+    throw new Error('You have to pass an array object to setMockData.');
+  }
+  for (const mock of mockDataArr) {
+    responseMapping.set(mock.funcName, {
+      isSuccess: mock.isSuccess ? true : false,
+      response: mock.response
+    });
+  }
+}
+
 class Runner {
   constructor() {
     return enableServerMockedMethods(this);
@@ -95,10 +110,28 @@ class Runner {
   __mockedMethod__(name) {
     const style = 'color: white; font-style: bold; background-color: #0277BD; padding: 2px 5px; border-radius: 3px;'
     console.info(`In production, you would have called the server-side %c${name} method`, style);
-    if (this.successHandler) {
-      setTimeout(() => {
+
+    if (responseMapping.has(name)) {
+      const mockInfo = responseMapping.get(name);
+      if (mockInfo.isSuccess) {
+        if (this.successHandler) {
+          setTimeout(() => {
+            this.successHandler(mockInfo.response, this.userObject);
+          }, 0);
+        }
+      } else {
+        if (this.failureHandler) {
+          setTimeout(() => {
+            this.failureHandler(mockInfo.response, this.userObject);
+          }, 0);
+        }
+      }
+    } else {
+      if (this.successHandler) {
+        setTimeout(() => {
           this.successHandler('in case of success it would respond within the successHandler callback, with the following user object:', this.userObject);
-      }, 0);
+        }, 0);
+      }
     }
   }
 }
@@ -128,5 +161,6 @@ class GoogleMock {
 }
 
 export default {
-  script: new GoogleMock()
+  script: new GoogleMock(),
+  setMockData
 }

--- a/google.mock/index.js
+++ b/google.mock/index.js
@@ -73,20 +73,20 @@ const enableServerMockedMethods = (obj) => {
   });
 }
 
-let responseMapping;
-
-const setMockData = (mockDataArr) => {
-  responseMapping = new Map();
-  if (!Array.isArray(mockDataArr)) {
-    throw new Error('You have to pass an array object to setMockData.');
+const initializeMockData = (mockData) => {
+  const mapper = new Map();
+  if (mockData) {
+    for (const functionName of Object.keys(mockData)) {
+      mapper.set(functionName, {
+        isSuccess: mockData[functionName].isSuccess ? true : false,
+        response: mockData[functionName].response
+      });
+    }
   }
-  for (const mock of mockDataArr) {
-    responseMapping.set(mock.funcName, {
-      isSuccess: mock.isSuccess ? true : false,
-      response: mock.response
-    });
-  }
+  return mapper;
 }
+
+const responseMapping = initializeMockData(__GOOGLE_MOCK_RESPONSES__);
 
 class Runner {
   constructor() {
@@ -161,6 +161,5 @@ class GoogleMock {
 }
 
 export default {
-  script: new GoogleMock(),
-  setMockData
+  script: new GoogleMock()
 }

--- a/utils/fileUpdater.js
+++ b/utils/fileUpdater.js
@@ -14,8 +14,6 @@ const updaters = (api, options) => {
     lines[0] = [
       `import google from '@ijusplab/vue-cli-plugin-gas/google.mock'`,
       `import VueGasPlugin from '@ijusplab/vue-cli-plugin-gas/utils/VueGasPlugin'`,
-      `// @ts-ignore`,
-      `import { sampleMockData } from './mock-data/responseMock'`,
       lines[0]
     ].join('\n');
 
@@ -35,10 +33,6 @@ const updaters = (api, options) => {
     lineIndex = lines.findIndex(line => line.match(/new Vue/));
     lines[lineIndex - 1] = [
       lines[lineIndex - 1],
-      `if (process.env.NODE_ENV !== 'production' && google.setMockData && sampleMockData) {`,
-      `  google.setMockData(sampleMockData);`,
-      `}`,
-      ``,
       `Vue.use(VueGasPlugin, {`,
       `  google,`,
       `  devMode: process.env.NODE_ENV !== 'production'`,

--- a/utils/fileUpdater.js
+++ b/utils/fileUpdater.js
@@ -14,6 +14,8 @@ const updaters = (api, options) => {
     lines[0] = [
       `import google from '@ijusplab/vue-cli-plugin-gas/google.mock'`,
       `import VueGasPlugin from '@ijusplab/vue-cli-plugin-gas/utils/VueGasPlugin'`,
+      `// @ts-ignore`,
+      `import { sampleMockData } from './mock-data/responseMock'`,
       lines[0]
     ].join('\n');
 
@@ -33,6 +35,10 @@ const updaters = (api, options) => {
     lineIndex = lines.findIndex(line => line.match(/new Vue/));
     lines[lineIndex - 1] = [
       lines[lineIndex - 1],
+      `if (process.env.NODE_ENV !== 'production' && google.setMockData && sampleMockData) {`,
+      `  google.setMockData(sampleMockData);`,
+      `}`,
+      ``,
       `Vue.use(VueGasPlugin, {`,
       `  google,`,
       `  devMode: process.env.NODE_ENV !== 'production'`,

--- a/utils/getPackageExtension.js
+++ b/utils/getPackageExtension.js
@@ -27,6 +27,8 @@ module.exports = (api, { addLicense, licenseName }) => {
           before: function (app, server, compiler) {
             let googleMock = '@ijusplab/vue-cli-plugin-gas/google.mock'
             if (googleMock in config.externals) delete config.externals[googleMock]
+            let responseMoc = './mock-data/responseMock'
+            if (responseMoc in config.externals) delete config.externals[responseMoc]
           }
         };
         config.optimization = {
@@ -39,7 +41,8 @@ module.exports = (api, { addLicense, licenseName }) => {
           'vue-router': 'VueRouter',
           'vuetify/dist/vuetify.min.css': 'undefined',
           'vuetify/lib': 'Vuetify',
-          '@ijusplab/vue-cli-plugin-gas/google.mock': 'google'
+          '@ijusplab/vue-cli-plugin-gas/google.mock': 'google',
+          './mock-data/responseMock': 'undefined'
         };
       },
       chainWebpack: config => {

--- a/utils/getPackageExtension.js
+++ b/utils/getPackageExtension.js
@@ -27,8 +27,6 @@ module.exports = (api, { addLicense, licenseName }) => {
           before: function (app, server, compiler) {
             let googleMock = '@ijusplab/vue-cli-plugin-gas/google.mock'
             if (googleMock in config.externals) delete config.externals[googleMock]
-            let responseMoc = './mock-data/responseMock'
-            if (responseMoc in config.externals) delete config.externals[responseMoc]
           }
         };
         config.optimization = {
@@ -41,8 +39,7 @@ module.exports = (api, { addLicense, licenseName }) => {
           'vue-router': 'VueRouter',
           'vuetify/dist/vuetify.min.css': 'undefined',
           'vuetify/lib': 'Vuetify',
-          '@ijusplab/vue-cli-plugin-gas/google.mock': 'google',
-          './mock-data/responseMock': 'undefined'
+          '@ijusplab/vue-cli-plugin-gas/google.mock': 'google'
         };
       },
       chainWebpack: config => {
@@ -60,6 +57,16 @@ module.exports = (api, { addLicense, licenseName }) => {
           .use('vue-svg-inline-loader')
           .loader('vue-svg-inline-loader')
           .options({ /* ... */ });
+
+        config.plugin('define').tap(definitions => {
+          if (process.env.NODE_ENV !== 'production') {
+            const mockFilePath = './src/mock-data/responseMock.js';
+            definitions[0] = Object.assign(definitions[0], {
+              __GOOGLE_MOCK_RESPONSES__: require('fs').existsSync(mockFilePath) ? require(mockFilePath) : null
+            });
+          }
+          return definitions;
+        });
 
         if (config.plugins.has('preload-app')) config.plugins.delete('preload-app');
         if (config.plugins.has('prefetch-app')) config.plugins.delete('prefetch-app');


### PR DESCRIPTION
This is suggestion.
In development, `google.mock` does not return response that I assume. So I think it is useful that `google.mock` has method which setup mock data. I implemented as following.
* Users can set mockdata, and server-side function success or failed.
* In product mode, mock data file is not bundled by webpack.

How about that ?