### PR TITLE
More reliable way to check on a clasp install

### DIFF
--- a/utils/claspHelpers.js
+++ b/utils/claspHelpers.js
@@ -50,7 +50,7 @@ const getPaths = (api) => {
 
 const isInstalled = () => {
   try {
-    const raw = getJson(require.resolve('@google/clasp/package.json')).version;
+    const raw = execSync('clasp --version').toString()
     let [major, minor, patch] = raw.split('.').map(n => parseInt(n, 10));
     let min = '2.3.0';
     let isCompatible = major > 2 || (major === 2 && minor >= 3);


### PR DESCRIPTION
# Summary

There have been issues (#5, #9) reported with this generator not properly seeing globally installed versions of `clasp`. The original code actually was trying to pull the `package.json` of clasp from NODE_PATH, which often times is unreliable -- i.e. the developer could be running nvm, n, etc

This PR changes the way this dependency is checked. It does a straight `execSync('clasp --version')` which should cover the cases above as well as for people who just have one version of Node installed.

This will also make the README.md more consistent, as the direction can just be to do an `npm i -g @google/clasp` or `yarn add global @google/clasp`