### PR TITLE
Support for clasp latest version.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,7 @@
 
 This is a Vue CLI plugin that will help you to setup a Google Apps Script project using [Vue](https://vuejs.org/) as the front-end tool. The plugin already integrates [clasp](https://github.com/google/clasp/) commands. For example, it will initialize your project by executing `clasp clone` or `clasp create`. It will also enable you to bundle and deploy your code by automatically syncing the manifest file, building your code for production to the `dist` folder and running `clasp push` or `clasp deploy`.
 
-This plugins expects you to have at least version `2.3.0` of Clasp installed. 
+This plugins expects you to have at least version `2.4.1` of Clasp installed. 
 
 ### Setup:
 

--- a/utils/claspHelpers.js
+++ b/utils/claspHelpers.js
@@ -52,8 +52,8 @@ const isInstalled = () => {
   try {
     const raw = getJson(require.resolve('@google/clasp/package.json')).version;
     let [major, minor, patch] = raw.split('.').map(n => parseInt(n, 10));
-    let min = '2.3.0';
-    let isCompatible = major > 2 || (major === 2 && minor >= 3);
+    let min = '2.4.1';
+    let isCompatible = major > 2 || (major === 2 && minor >= 4 && patch >= 1 );
     return { major, minor, patch, raw, min, isCompatible };
   } catch (e) {
     console.error(e);
@@ -74,6 +74,7 @@ const create = (context, { scriptType, appName }) => {
   if (!scriptType) throw new Error('ScriptType not defined');
   if (!appName) throw new Error('AppName not defined');
   execSync(`cd ${context.root} && clasp create --type ${scriptType} --title "${appName}" --rootDir ./dist`, { stdio: 'inherit' });
+  moveFiles(path.resolve(context.dist, '.clasp.json'), context.root)
 };
 
 const clone = (context, { scriptId }) => {


### PR DESCRIPTION
## Summary

Clasp version v2.4.1 and onwards, clasp configuration file(`.clasp.json`) location was changed. So, failed to install plugin.

I have made adjustments to move the files, because this plugin relies on the location in the previous version.
Further details can be found here.
* https://github.com/google/clasp/issues/869#issuecomment-1207223999

## Tested environment

|component|version|
|---|---|
|Node.js|16.20.0|
|Vue Cli|4.5.19|
|Vue|2.7.14|
|Clasp|2.4.1 and 2.4.2|

Execute the following command to confirm.
```bash
$ vue invoke @ijusplab/vue-cli-plugin-gas
$ yarn deploy
```